### PR TITLE
destringify target date to see if that fixes mobile display

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@ import Header from './components/header'
 import './App.css';
 
 function App() {
-  const targetDate = new Date('2029,11,31').getTime();
+  const targetDate = new Date(2029,11,31).getTime();
   return (
     <div>
       <div className='container'>


### PR DESCRIPTION
Countdown display on mobile safari still showing as NaN. Seeing if passing in the target date not as a string will fix it.